### PR TITLE
feat: add keepalive for sync test <-> api integration

### DIFF
--- a/pkg/api/store.go
+++ b/pkg/api/store.go
@@ -60,7 +60,7 @@ func NewStore(log logrus.FieldLogger) *Store {
 }
 
 func (s *Store) Start() {
-	s.cleanupTick = time.NewTicker(time.Hour)
+	s.cleanupTick = time.NewTicker(20 * time.Minute)
 	go s.cleanupLoop()
 }
 

--- a/pkg/reporting/types.go
+++ b/pkg/reporting/types.go
@@ -2,8 +2,8 @@ package reporting
 
 import "github.com/ethpandaops/syncoor/pkg/sysinfo"
 
-// Protocol messages
-type TestStartRequest struct {
+// TestKeepaliveRequest represents a keepalive request to maintain test connection
+type TestKeepaliveRequest struct {
 	RunID       string              `json:"run_id"`
 	Timestamp   int64               `json:"timestamp"`
 	Network     string              `json:"network"`

--- a/pkg/synctest/service.go
+++ b/pkg/synctest/service.go
@@ -238,7 +238,7 @@ func (s *service) Start(ctx context.Context) error {
 	// Report test start if reporting client is configured
 	if s.reportingClient != nil {
 		runID := fmt.Sprintf("sync-test-%d-%s_%s_%s", time.Now().UnixNano(), s.cfg.Network, s.cfg.ELClient, s.cfg.CLClient)
-		startReq := reporting.TestStartRequest{
+		startReq := reporting.TestKeepaliveRequest{
 			RunID:     runID,
 			Timestamp: time.Now().Unix(),
 			Network:   s.cfg.Network,
@@ -257,7 +257,7 @@ func (s *service) Start(ctx context.Context) error {
 			SystemInfo:  systemInfo,
 		}
 
-		if err := s.reportingClient.ReportTestStart(ctx, startReq); err != nil {
+		if err := s.reportingClient.ReportTestKeepAlive(ctx, startReq); err != nil {
 			s.log.WithError(err).Warn("Failed to report test start")
 			// Continue anyway - reporting is optional
 		}


### PR DESCRIPTION
Instead of just a single "start" request. This makes it possible for the api server to be restarted and recover it's data once it gets the next keepalive request