### PR TITLE
fix(action): add job id to artifact-name

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -569,7 +569,7 @@ runs:
       uses: actions/upload-artifact@v4
       if: always() && inputs.upload-artifacts == 'true' && inputs.run-tests == 'true'
       with:
-        name: ${{ inputs.network }}-${{ inputs.el-client }}-${{ inputs.cl-client }}-sync-report
+        name: ${{ inputs.network }}-${{ inputs.el-client }}-${{ inputs.cl-client }}-report-${{ steps.get-job-id.outputs.job_id }}
         path: ${{ runner.temp }}/reports
         retention-days: ${{ inputs.artifact-retention-days-test-report }}
 
@@ -595,7 +595,7 @@ runs:
       uses: actions/upload-artifact@v4
       if: steps.enclave-dump.outputs.dump_created == 'true'
       with:
-        name: ${{ inputs.network }}-${{ inputs.el-client }}-${{ inputs.cl-client }}-kurtosis-enclave-dump
+        name: ${{ inputs.network }}-${{ inputs.el-client }}-${{ inputs.cl-client }}-kurtosis-dump-${{ steps.get-job-id.outputs.job_id }}
         path: kurtosis-enclave-dump
         retention-days: ${{ inputs.artifact-retention-days-enclave-dump }}
 


### PR DESCRIPTION
In some situations, we might trigger 2 jobs that have the same network + el-client + cl-client in the same workflow run. I'm appending the job id, to avoid artifact naming conflicts.