### PR TITLE
fix(action): fetch more jobs to get job_id

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -340,7 +340,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github-token }}
       run: |
-        jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs)
+        jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs -F per_page=100)
         job_id=$(echo $jobs | jq -r '.jobs[] | select(.runner_name=="${{ runner.name }}") | .id')
         echo "job_id=$job_id" >> $GITHUB_OUTPUT
 

--- a/action.yaml
+++ b/action.yaml
@@ -340,7 +340,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github-token }}
       run: |
-        jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs -F per_page=100)
+        jobs=$(gh api -F per_page=100 -X GET repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs)
         job_id=$(echo $jobs | jq -r '.jobs[] | select(.runner_name=="${{ runner.name }}") | .id')
         echo "job_id=$job_id" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
In some workflows with 60 jobs, we didn't manage to get the job id, most likely due to pagination limits.