### PR TITLE
ci: also push Docker images to Docker Hub

### DIFF
--- a/.github/workflows/deploy-docker.web.yaml
+++ b/.github/workflows/deploy-docker.web.yaml
@@ -19,12 +19,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Deploy docker images
+      - name: Deploy to GHCR
         uses: ethpandaops/actions/docker-build-push@7d7b7bfe36fe4cfa538acd0e23706a23ce07c3ac # master
         with:
           registry: ghcr.io
           registry_username: ${{ github.actor }}
           registry_password: ${{ secrets.GITHUB_TOKEN }}
+          image_name: ${{ github.repository }}-web
+          push: true
+          platforms: linux/amd64,linux/arm64
+          file: Dockerfile.web
+
+      - name: Deploy to Docker Hub
+        uses: ethpandaops/actions/docker-build-push@7d7b7bfe36fe4cfa538acd0e23706a23ce07c3ac # master
+        with:
+          registry: docker.io
+          registry_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          registry_password: ${{ secrets.DOCKERHUB_TOKEN }}
           image_name: ${{ github.repository }}-web
           push: true
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -19,12 +19,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Deploy docker images
+      - name: Deploy to GHCR
         uses: ethpandaops/actions/docker-build-push@7d7b7bfe36fe4cfa538acd0e23706a23ce07c3ac # master
         with:
           registry: ghcr.io
           registry_username: ${{ github.actor }}
           registry_password: ${{ secrets.GITHUB_TOKEN }}
+          image_name: ${{ github.repository }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          file: Dockerfile
+
+      - name: Deploy to Docker Hub
+        uses: ethpandaops/actions/docker-build-push@7d7b7bfe36fe4cfa538acd0e23706a23ce07c3ac # master
+        with:
+          registry: docker.io
+          registry_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          registry_password: ${{ secrets.DOCKERHUB_TOKEN }}
           image_name: ${{ github.repository }}
           push: true
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary
Mirrors every release-tag and master push into Docker Hub in addition to the existing GHCR publishes. Uses the same `ethpandaops/actions/docker-build-push` composite action the workflow already uses, with `registry: docker.io` and Docker Hub credentials — same pattern as `ethpandaops/dora`.

Result after merge:
- `ghcr.io/ethpandaops/syncoor:{master,0.2.6,...}` (unchanged)
- `docker.io/ethpandaops/syncoor:{master,0.2.6,...}` (new)
- `ghcr.io/ethpandaops/syncoor-web:{master,0.2.6,...}` (unchanged)
- `docker.io/ethpandaops/syncoor-web:{master,0.2.6,...}` (new)

Uses repo secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`.

## Why
The testnet workflows (bal-devnets, blob-devnets, epbs-devnets, lean-devnets, etc.) pull from `docker.ethquokkaops.io/dh/ethpandaops/syncoor:master`, which is a Docker Hub mirror. The mirror has been stale since 2026-03-18 because nothing has pushed to `docker.io/ethpandaops/syncoor` since then; syncoor only publishes to GHCR today. Pushing to Docker Hub unblocks that path.

## Test plan
- [ ] On merge, `Deploy - Docker` pushes both `ghcr.io` and `docker.io` tags.
- [ ] `docker pull docker.io/ethpandaops/syncoor:master` from a clean host succeeds.
- [ ] Next testnet syncoor run picks up a fresh `:master` image.