### PR TITLE
ci: multi-arch docker build with native arm64 runners

### DIFF
--- a/.github/workflows/deploy-docker.web.yaml
+++ b/.github/workflows/deploy-docker.web.yaml
@@ -7,36 +7,206 @@ on:
     tags:
       - 'v*.*.*'
 
-jobs:
-  build-and-push-image:
-    runs-on: ubuntu-latest
+env:
+  GHCR_REPO: ghcr.io/${{ github.repository }}-web
+  DOCKERHUB_REPO: docker.io/${{ github.repository }}-web
+  DOCKERFILE: Dockerfile.web
 
+jobs:
+  meta:
+    name: Compute tags
+    runs-on: ubuntu-latest
+    outputs:
+      sha_short: ${{ steps.vars.outputs.sha_short }}
+      tag_prefix: ${{ steps.vars.outputs.tag_prefix }}
+      additional_tags: ${{ steps.vars.outputs.additional_tags }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - id: vars
+        run: |
+          SHA_SHORT=$(git rev-parse --short HEAD)
+          echo "sha_short=$SHA_SHORT" >> $GITHUB_OUTPUT
+          if [[ "${{ github.ref }}" == refs/tags/v*.*.* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+            echo "tag_prefix=$VERSION" >> $GITHUB_OUTPUT
+            echo "additional_tags=[\"$VERSION\",\"latest\"]" >> $GITHUB_OUTPUT
+          else
+            echo "tag_prefix=master" >> $GITHUB_OUTPUT
+            echo "additional_tags=[\"master\",\"master-latest\"]" >> $GITHUB_OUTPUT
+          fi
+
+  build_amd64:
+    name: Build amd64 image
+    needs: meta
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Deploy to GHCR
-        uses: ethpandaops/actions/docker-build-push@7d7b7bfe36fe4cfa538acd0e23706a23ce07c3ac # master
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io
-          registry_username: ${{ github.actor }}
-          registry_password: ${{ secrets.GITHUB_TOKEN }}
-          image_name: ${{ github.repository }}-web
-          push: true
-          platforms: linux/amd64,linux/arm64
-          file: Dockerfile.web
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Deploy to Docker Hub
-        uses: ethpandaops/actions/docker-build-push@7d7b7bfe36fe4cfa538acd0e23706a23ce07c3ac # master
+      - name: Log in to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: docker.io
-          registry_username: ${{ secrets.DOCKERHUB_USERNAME }}
-          registry_password: ${{ secrets.DOCKERHUB_TOKEN }}
-          image_name: ${{ github.repository }}-web
-          push: true
-          platforms: linux/amd64,linux/arm64
-          file: Dockerfile.web
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build amd64 docker image
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+        run: |
+          docker build . --file "$DOCKERFILE" \
+            --tag "${GHCR_REPO}:${PREFIX}-amd64" \
+            --tag "${GHCR_REPO}:${PREFIX}-${SHA}-amd64" \
+            --tag "${DOCKERHUB_REPO}:${PREFIX}-amd64" \
+            --tag "${DOCKERHUB_REPO}:${PREFIX}-${SHA}-amd64" \
+            --platform=linux/amd64
+
+      - name: Push amd64 docker images
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+        run: |
+          docker push "${GHCR_REPO}:${PREFIX}-amd64"
+          docker push "${GHCR_REPO}:${PREFIX}-${SHA}-amd64"
+          docker push "${DOCKERHUB_REPO}:${PREFIX}-amd64"
+          docker push "${DOCKERHUB_REPO}:${PREFIX}-${SHA}-amd64"
+
+  build_arm64:
+    name: Build arm64 image
+    needs: meta
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build arm64 docker image
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+        run: |
+          docker build . --file "$DOCKERFILE" \
+            --tag "${GHCR_REPO}:${PREFIX}-arm64" \
+            --tag "${GHCR_REPO}:${PREFIX}-${SHA}-arm64" \
+            --tag "${DOCKERHUB_REPO}:${PREFIX}-arm64" \
+            --tag "${DOCKERHUB_REPO}:${PREFIX}-${SHA}-arm64" \
+            --platform=linux/arm64
+
+      - name: Push arm64 docker images
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+        run: |
+          docker push "${GHCR_REPO}:${PREFIX}-arm64"
+          docker push "${GHCR_REPO}:${PREFIX}-${SHA}-arm64"
+          docker push "${DOCKERHUB_REPO}:${PREFIX}-arm64"
+          docker push "${DOCKERHUB_REPO}:${PREFIX}-${SHA}-arm64"
+
+  manifest_sha:
+    name: Multi-arch sha manifest
+    needs: [meta, build_amd64, build_arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create multi-arch sha manifest
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+        run: |
+          for repo in "$GHCR_REPO" "$DOCKERHUB_REPO"; do
+            docker buildx imagetools create -t "${repo}:${PREFIX}-${SHA}" \
+              "${repo}:${PREFIX}-${SHA}-amd64" \
+              "${repo}:${PREFIX}-${SHA}-arm64"
+          done
+
+  manifest_extra:
+    name: Multi-arch additional manifests
+    needs: [meta, build_amd64, build_arm64]
+    if: ${{ needs.meta.outputs.additional_tags != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        tag: ${{ fromJSON(needs.meta.outputs.additional_tags) }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create multi-arch manifest ${{ matrix.tag }}
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+          TAG: ${{ matrix.tag }}
+        run: |
+          for repo in "$GHCR_REPO" "$DOCKERHUB_REPO"; do
+            docker buildx imagetools create -t "${repo}:${TAG}" \
+              "${repo}:${PREFIX}-${SHA}-amd64" \
+              "${repo}:${PREFIX}-${SHA}-arm64"
+          done

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -7,36 +7,206 @@ on:
     tags:
       - 'v*.*.*'
 
-jobs:
-  build-and-push-image:
-    runs-on: ubuntu-latest
+env:
+  GHCR_REPO: ghcr.io/${{ github.repository }}
+  DOCKERHUB_REPO: docker.io/${{ github.repository }}
+  DOCKERFILE: Dockerfile
 
+jobs:
+  meta:
+    name: Compute tags
+    runs-on: ubuntu-latest
+    outputs:
+      sha_short: ${{ steps.vars.outputs.sha_short }}
+      tag_prefix: ${{ steps.vars.outputs.tag_prefix }}
+      additional_tags: ${{ steps.vars.outputs.additional_tags }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - id: vars
+        run: |
+          SHA_SHORT=$(git rev-parse --short HEAD)
+          echo "sha_short=$SHA_SHORT" >> $GITHUB_OUTPUT
+          if [[ "${{ github.ref }}" == refs/tags/v*.*.* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+            echo "tag_prefix=$VERSION" >> $GITHUB_OUTPUT
+            echo "additional_tags=[\"$VERSION\",\"latest\"]" >> $GITHUB_OUTPUT
+          else
+            echo "tag_prefix=master" >> $GITHUB_OUTPUT
+            echo "additional_tags=[\"master\",\"master-latest\"]" >> $GITHUB_OUTPUT
+          fi
+
+  build_amd64:
+    name: Build amd64 image
+    needs: meta
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Deploy to GHCR
-        uses: ethpandaops/actions/docker-build-push@7d7b7bfe36fe4cfa538acd0e23706a23ce07c3ac # master
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io
-          registry_username: ${{ github.actor }}
-          registry_password: ${{ secrets.GITHUB_TOKEN }}
-          image_name: ${{ github.repository }}
-          push: true
-          platforms: linux/amd64,linux/arm64
-          file: Dockerfile
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Deploy to Docker Hub
-        uses: ethpandaops/actions/docker-build-push@7d7b7bfe36fe4cfa538acd0e23706a23ce07c3ac # master
+      - name: Log in to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: docker.io
-          registry_username: ${{ secrets.DOCKERHUB_USERNAME }}
-          registry_password: ${{ secrets.DOCKERHUB_TOKEN }}
-          image_name: ${{ github.repository }}
-          push: true
-          platforms: linux/amd64,linux/arm64
-          file: Dockerfile
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build amd64 docker image
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+        run: |
+          docker build . --file "$DOCKERFILE" \
+            --tag "${GHCR_REPO}:${PREFIX}-amd64" \
+            --tag "${GHCR_REPO}:${PREFIX}-${SHA}-amd64" \
+            --tag "${DOCKERHUB_REPO}:${PREFIX}-amd64" \
+            --tag "${DOCKERHUB_REPO}:${PREFIX}-${SHA}-amd64" \
+            --platform=linux/amd64
+
+      - name: Push amd64 docker images
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+        run: |
+          docker push "${GHCR_REPO}:${PREFIX}-amd64"
+          docker push "${GHCR_REPO}:${PREFIX}-${SHA}-amd64"
+          docker push "${DOCKERHUB_REPO}:${PREFIX}-amd64"
+          docker push "${DOCKERHUB_REPO}:${PREFIX}-${SHA}-amd64"
+
+  build_arm64:
+    name: Build arm64 image
+    needs: meta
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build arm64 docker image
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+        run: |
+          docker build . --file "$DOCKERFILE" \
+            --tag "${GHCR_REPO}:${PREFIX}-arm64" \
+            --tag "${GHCR_REPO}:${PREFIX}-${SHA}-arm64" \
+            --tag "${DOCKERHUB_REPO}:${PREFIX}-arm64" \
+            --tag "${DOCKERHUB_REPO}:${PREFIX}-${SHA}-arm64" \
+            --platform=linux/arm64
+
+      - name: Push arm64 docker images
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+        run: |
+          docker push "${GHCR_REPO}:${PREFIX}-arm64"
+          docker push "${GHCR_REPO}:${PREFIX}-${SHA}-arm64"
+          docker push "${DOCKERHUB_REPO}:${PREFIX}-arm64"
+          docker push "${DOCKERHUB_REPO}:${PREFIX}-${SHA}-arm64"
+
+  manifest_sha:
+    name: Multi-arch sha manifest
+    needs: [meta, build_amd64, build_arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create multi-arch sha manifest
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+        run: |
+          for repo in "$GHCR_REPO" "$DOCKERHUB_REPO"; do
+            docker buildx imagetools create -t "${repo}:${PREFIX}-${SHA}" \
+              "${repo}:${PREFIX}-${SHA}-amd64" \
+              "${repo}:${PREFIX}-${SHA}-arm64"
+          done
+
+  manifest_extra:
+    name: Multi-arch additional manifests
+    needs: [meta, build_amd64, build_arm64]
+    if: ${{ needs.meta.outputs.additional_tags != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        tag: ${{ fromJSON(needs.meta.outputs.additional_tags) }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create multi-arch manifest ${{ matrix.tag }}
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+          TAG: ${{ matrix.tag }}
+        run: |
+          for repo in "$GHCR_REPO" "$DOCKERHUB_REPO"; do
+            docker buildx imagetools create -t "${repo}:${TAG}" \
+              "${repo}:${PREFIX}-${SHA}-amd64" \
+              "${repo}:${PREFIX}-${SHA}-arm64"
+          done


### PR DESCRIPTION
## Summary
Restructures `deploy-docker.yaml` and `deploy-docker.web.yaml` to match the `ethpandaops/dora` build pattern:

- **Native per-arch jobs**: amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`. No QEMU emulation — cuts arm64 build time roughly in half.
- **Two-phase**: each arch is built and pushed with its own `-amd64`/`-arm64` suffix; a final `manifest_*` job fuses them into multi-arch manifests via `docker buildx imagetools create`.
- **Pushes to GHCR and Docker Hub in parallel** from every job.
- **Immutable `<tag>-<sha>` pins** for downstream pinning.

### Tags produced

**master push:**
```
ghcr.io/ethpandaops/syncoor:master-amd64
ghcr.io/ethpandaops/syncoor:master-arm64
ghcr.io/ethpandaops/syncoor:master-<sha>-amd64
ghcr.io/ethpandaops/syncoor:master-<sha>-arm64
ghcr.io/ethpandaops/syncoor:master-<sha>         (multi-arch)
ghcr.io/ethpandaops/syncoor:master               (multi-arch)
ghcr.io/ethpandaops/syncoor:master-latest        (multi-arch alias)
```
(plus the same set under `docker.io/ethpandaops/syncoor`, and the same pattern for `syncoor-web`.)

**v*.*.* push:** same shape, with `master` replaced by the version and `master-latest` replaced by `latest`.

### Why
- Matches the dora tag set, including the `<branch>-<linux-arch>` and `<branch>-<sha>-<linux-arch>` per-arch pins that used to appear on Docker Hub before March 18 (see discussion on #148).
- Native ARM runners avoid QEMU — arm64 builds finish in roughly native amd64 time.
- Keeps GHCR publishing identical to before in content, just with an expanded tag set.

## Test plan
- [ ] Merge and observe `build_amd64`, `build_arm64`, `manifest_sha`, `manifest_extra` all green.
- [ ] `docker buildx imagetools inspect docker.io/ethpandaops/syncoor:master` shows both linux/amd64 and linux/arm64.
- [ ] Pull `docker.io/ethpandaops/syncoor:master-<sha>` from an arm64 host and from an amd64 host — both succeed.
- [ ] Next testnet syncoor run picks up the fresh images.