### PR TITLE
feat: support ethrex and nimbus-eth1 execution clients

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/docker/go-connections v0.7.0
-	github.com/ethpandaops/ethereum-package-go v0.9.1-0.20260422164037-c62bddc24d06
+	github.com/ethpandaops/ethereum-package-go v0.10.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/kurtosis-tech/kurtosis/api/golang v1.18.1
 	github.com/moby/moby/api v1.52.0-alpha.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/docker/go-connections v0.7.0
-	github.com/ethpandaops/ethereum-package-go v0.9.0
+	github.com/ethpandaops/ethereum-package-go v0.9.1-0.20260422164037-c62bddc24d06
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/kurtosis-tech/kurtosis/api/golang v1.18.1
 	github.com/moby/moby/api v1.52.0-alpha.1

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/ethpandaops/ethereum-package-go v0.9.0 h1:3LXo8tHV/GQ81hE8laEwcpxOT/GJW2PeAaMiQ9adsGA=
-github.com/ethpandaops/ethereum-package-go v0.9.0/go.mod h1:t/JxwHlHCATh0FfQTiE5+kn1yg6wQ3NJtiBQ0n5MW84=
+github.com/ethpandaops/ethereum-package-go v0.9.1-0.20260422164037-c62bddc24d06 h1:+gSOITMMnPdHts0jcv01KBgnwtuQDMjZBGoWIK6DYQE=
+github.com/ethpandaops/ethereum-package-go v0.9.1-0.20260422164037-c62bddc24d06/go.mod h1:t/JxwHlHCATh0FfQTiE5+kn1yg6wQ3NJtiBQ0n5MW84=
 github.com/ethpandaops/go-eth2-client v0.1.0 h1:migUQIIL3fcWWMmIwF4Rh05rvJPuj+LOgDJkIWZ+gIE=
 github.com/ethpandaops/go-eth2-client v0.1.0/go.mod h1:9BBd/XIw1egZTkxtFGMvgXnsxX6ypKHKNKD7itqjmNQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/ethpandaops/ethereum-package-go v0.9.1-0.20260422164037-c62bddc24d06 h1:+gSOITMMnPdHts0jcv01KBgnwtuQDMjZBGoWIK6DYQE=
-github.com/ethpandaops/ethereum-package-go v0.9.1-0.20260422164037-c62bddc24d06/go.mod h1:t/JxwHlHCATh0FfQTiE5+kn1yg6wQ3NJtiBQ0n5MW84=
+github.com/ethpandaops/ethereum-package-go v0.10.0 h1:q/TTZGWMjZmcuweASv14TEXxdPczCXMV2dAgCldQieA=
+github.com/ethpandaops/ethereum-package-go v0.10.0/go.mod h1:t/JxwHlHCATh0FfQTiE5+kn1yg6wQ3NJtiBQ0n5MW84=
 github.com/ethpandaops/go-eth2-client v0.1.0 h1:migUQIIL3fcWWMmIwF4Rh05rvJPuj+LOgDJkIWZ+gIE=
 github.com/ethpandaops/go-eth2-client v0.1.0/go.mod h1:9BBd/XIw1egZTkxtFGMvgXnsxX6ypKHKNKD7itqjmNQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/pkg/kurtosis-log/streamer.go
+++ b/pkg/kurtosis-log/streamer.go
@@ -247,7 +247,7 @@ func (s *Streamer) logClientMessage(clientType, message string) {
 	// Determine emoji based on client type
 	var emoji string
 	switch strings.ToLower(clientType) {
-	case "geth", "nethermind", "besu", "erigon", "reth", "nimbusel":
+	case "geth", "nethermind", "besu", "erigon", "reth", "ethrex", "nimbusel":
 		emoji = "🔵" // Execution layer clients
 	case "lighthouse", "prysm", "teku", "nimbus", "lodestar", "grandine":
 		emoji = "🟣" // Consensus layer clients


### PR DESCRIPTION
## Summary
Pulls in `ethpandaops/ethereum-package-go` v0.10.0 (ethpandaops/ethereum-package-go#18) which adds `client.Ethrex` and `client.NimbusEth1` plus a `MarshalYAML` that translates the user-facing `"nimbusel"` alias to the `"nimbus"` wire name upstream `ethereum-package` expects. Without it, bal-devnets / blob-devnets / etc. dispatches hit `invalid execution client type: ethrex` or `...: nimbusel` at config-validation time.

This PR:
- Bumps `ethereum-package-go` to `v0.10.0`.
- Adds `ethrex` to the EL emoji switch in `pkg/kurtosis-log/streamer.go` so ethrex client logs are tagged as execution-layer.

## Why now
Example failure from today: https://github.com/ethpandaops/bal-devnets/actions/runs/24789570776/job/72543001852
```
FATA Failed to start sync test: failed to start network: failed to build configuration: participant 0: invalid execution client type: ethrex
```

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all clean locally
- [ ] CI green
- [ ] After merge, cut a syncoor release and retrigger a bal-devnets syncoor-devnet-3 dispatch with `el-client: ethrex`