### PR TITLE
fix(web): render ANSI color codes in logs regardless of first line

### DIFF
--- a/web/src/components/FileViewer.tsx
+++ b/web/src/components/FileViewer.tsx
@@ -311,25 +311,6 @@ export function FileViewer({
   };
 
   const buildLineContents = (text: string, lines: string[]): { nodes: React.ReactNode[]; wrapperClass: string } => {
-    const firstLine = lines[0] || '';
-    const ansiRegex = new RegExp(String.fromCharCode(27) + '\\[[0-9;]*m');
-
-    if (ansiRegex.test(firstLine)) {
-      const convert = new Convert({
-        fg: '#000',
-        bg: '#FFF',
-        newline: false,
-        escapeXML: true,
-        stream: false
-      });
-      return {
-        nodes: lines.map((line) => (
-          <span dangerouslySetInnerHTML={{ __html: convert.toHtml(line) }} />
-        )),
-        wrapperClass: ''
-      };
-    }
-
     if (fileType === 'json') {
       try {
         const highlightedHtml = Prism.highlight(text, Prism.languages.json, 'json');
@@ -358,8 +339,18 @@ export function FileViewer({
       }
     }
 
+    // Route all other text through ansi-to-html: it converts ANSI SGR
+    // sequences to styled spans and safely XML-escapes lines that have none,
+    // so mixed files (plain header + ANSI body) render correctly.
+    const convert = new Convert({
+      newline: false,
+      escapeXML: true,
+      stream: false,
+    });
     return {
-      nodes: lines.map((line) => <span>{line}</span>),
+      nodes: lines.map((line) => (
+        <span dangerouslySetInnerHTML={{ __html: convert.toHtml(line) }} />
+      )),
       wrapperClass: ''
     };
   };

--- a/web/src/components/FileViewer.tsx
+++ b/web/src/components/FileViewer.tsx
@@ -315,8 +315,8 @@ export function FileViewer({
       try {
         const highlightedHtml = Prism.highlight(text, Prism.languages.json, 'json');
         return {
-          nodes: highlightedHtml.split('\n').map((htmlLine) => (
-            <span dangerouslySetInnerHTML={{ __html: htmlLine }} />
+          nodes: highlightedHtml.split('\n').map((htmlLine, index) => (
+            <span key={index} dangerouslySetInnerHTML={{ __html: htmlLine }} />
           )),
           wrapperClass: 'syntax-json'
         };
@@ -329,8 +329,8 @@ export function FileViewer({
       try {
         const highlightedHtml = Prism.highlight(text, Prism.languages.yaml, 'yaml');
         return {
-          nodes: highlightedHtml.split('\n').map((htmlLine) => (
-            <span dangerouslySetInnerHTML={{ __html: htmlLine }} />
+          nodes: highlightedHtml.split('\n').map((htmlLine, index) => (
+            <span key={index} dangerouslySetInnerHTML={{ __html: htmlLine }} />
           )),
           wrapperClass: 'syntax-yaml'
         };
@@ -348,8 +348,8 @@ export function FileViewer({
       stream: false,
     });
     return {
-      nodes: lines.map((line) => (
-        <span dangerouslySetInnerHTML={{ __html: convert.toHtml(line) }} />
+      nodes: lines.map((line, index) => (
+        <span key={index} dangerouslySetInnerHTML={{ __html: convert.toHtml(line) }} />
       )),
       wrapperClass: ''
     };


### PR DESCRIPTION
## Summary
- `FileViewer` gated its ANSI→HTML conversion on `ansiRegex.test(text.split('\n')[0])`. Besu's `output.log` (and any log that starts with a non-ANSI preamble like `Listening for transport dt_socket at address: 48643` / `Setting logging level to INFO`) fails that check, so the whole file fell through to plain-text rendering and every later line showed its SGR codes literally (`[2m`, `[32m`, …) with the ESC byte rendered as a replacement glyph.
- Route all non-JSON/YAML text through `ansi-to-html` unconditionally. The library converts real ANSI sequences to styled spans and safely XML-escapes lines that have none, so a mixed file (plain header + ANSI body) renders correctly end-to-end.
- Drop the hard-coded `fg: '#000', bg: '#FFF'` defaults — those only affect SGR 39/49 "reset to default" (rare in logs) and forcing black-on-white broke dark-mode rendering.

## Test plan
- [ ] Open a Besu `el-*-besu-*/output.log` in the dump viewer and confirm timestamps/levels render in color, with no literal `[2m` / `[32m` fragments or replacement glyphs.
- [ ] Open a CL `output.log` (Lighthouse, Teku, …) and confirm ANSI coloring still works for files whose first line IS an ANSI-colored line.
- [ ] Open a log with no ANSI at all (e.g. `kurtosis.log` if applicable) — plain text still renders correctly, including `<`/`>`/`&` characters.
- [ ] View a `.json` and `.yaml` file — Prism syntax highlighting still applies.
- [ ] Toggle dark mode — logs remain readable; no black text on dark background.
- [ ] Toggle Wrap/Unwrap — ANSI-styled spans still wrap and line numbers stay aligned.